### PR TITLE
Removes an import for gaussTools

### DIFF
--- a/ZoneChecker.roboFontExt/info.plist
+++ b/ZoneChecker.roboFontExt/info.plist
@@ -28,7 +28,7 @@
 	<key>timeStamp</key>
 	<real>1482846829.75</real>
 	<key>version</key>
-	<string>0.1</string>
+	<string>0.2</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>

--- a/ZoneChecker.roboFontExt/lib/zoneCheckerTool.py
+++ b/ZoneChecker.roboFontExt/lib/zoneCheckerTool.py
@@ -6,7 +6,6 @@ from mojo.drawingTools import *
 from mojo.UI import UpdateCurrentGlyphView
 from defconAppKit.windows.baseWindow import BaseWindowController
 
-from gaussTools import *
 import vanilla
 
 from mojo.extensions import ExtensionBundle


### PR DESCRIPTION
Removes an import error for ``gaussTools`` which it doesn't look like the extension ends up using. I also bumped the version number from 0.1 to 0.2 if that's useful. Nice tool!